### PR TITLE
Printing the gameplan should display the old permissions in addition to the new ones.

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -86,7 +86,8 @@ export type UpdateTriggerCommand = {
 export type UpdateCollectionPermissionsCommand = {
   type: 'UpdateCollectionPermissions',
   collection: string,
-  definition: CollectionPermissions
+  definition: CollectionPermissions,
+  oldDefinition: CollectionPermissions
 }
 export type Command
   = AddCollectionCommand
@@ -230,12 +231,14 @@ UpdateTrigger.type = 'UpdateTrigger';
 
 const UpdateCollectionPermissions = (
   collection: string,
-  definition: CollectionPermissions
+  definition: CollectionPermissions,
+  oldDefinition: CollectionPermissions
 ): UpdateCollectionPermissionsCommand => (
   {
     type: UpdateCollectionPermissions.type,
     collection,
-    definition
+    definition,
+    oldDefinition
   }
 );
 UpdateCollectionPermissions.type = 'UpdateCollectionPermissions';
@@ -271,7 +274,7 @@ const prettyPrintCommand = (command: Command): string => {
     case UpdateTrigger.type:
       return `Update Trigger "${command.definition.triggerName}" on "${command.definition.className}"`;
     case UpdateCollectionPermissions.type:
-      return `Update Permissions on class "${command.collection}" to "${prettyPrintCollectionPermissions(command.definition)}"`;
+      return `Update Permissions on class "${command.collection}" to "${prettyPrintCollectionPermissions(command.definition)}" from "${prettyPrintCollectionPermissions(command.oldDefinition)}"`;
     default:
       return (command: empty); // exhaustiveness check
   }

--- a/src/planner.js
+++ b/src/planner.js
@@ -87,7 +87,7 @@ const planCollections = (
       const newPerms = collection.classLevelPermissions;
       const oldPerms = old.classLevelPermissions;
       if (!deepEquals(newPerms, oldPerms)) {
-        nc.push(UpdateCollectionPermissions(collection.className, newPerms));
+        nc.push(UpdateCollectionPermissions(collection.className, newPerms, oldPerms));
       }
     });
     return nc;

--- a/test/planner.js
+++ b/test/planner.js
@@ -202,7 +202,8 @@ describe('planner', function() {
       newSchema[0].classLevelPermissions.create['role:user'] = true
       const newPerms = UpdateCollectionPermissions(
         newSchema[0].className,
-        deepCopy(newSchema[0].classLevelPermissions)
+        deepCopy(newSchema[0].classLevelPermissions),
+        deepCopy(oldSchema[0].classLevelPermissions)
       );
       assert.deepEqual(
         planCollections(newSchema, oldSchema),


### PR DESCRIPTION
This PR adds better display output for permissions updates. This should help us figure out why the Lead permissions keep showing up as needing to change.

[IN-347](https://hustle-app.atlassian.net/browse/IN-347)